### PR TITLE
Update component to use new spring repository interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -65,13 +71,13 @@
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>${powermock.version}</version>
+			<version>2.0.0-beta.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito</artifactId>
-			<version>${powermock.version}</version>
+			<artifactId>powermock-api-mockito2</artifactId>
+			<version>2.0.0-beta.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/cloud/fogbow/accs/Main.java
+++ b/src/main/java/cloud/fogbow/accs/Main.java
@@ -4,6 +4,7 @@ import cloud.fogbow.accs.core.ApplicationFacade;
 import cloud.fogbow.accs.core.plugins.AccountingAuthPlugin;
 import cloud.fogbow.accs.core.processors.SyncProcessor;
 import cloud.fogbow.accs.core.PropertiesHolder;
+import cloud.fogbow.accs.core.datastore.DatabaseManager;
 import cloud.fogbow.common.constants.FogbowConstants;
 import cloud.fogbow.common.exceptions.FatalErrorException;
 import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
@@ -23,9 +24,14 @@ public class Main implements ApplicationRunner   {
     @Autowired
     SyncProcessor syncProcess;
 
+    @Autowired
+    private DatabaseManager dbManager;
+    
     @Override
     public void run(ApplicationArguments args) {
         try {
+        	ApplicationFacade.getInstance().setDatabaseManager(dbManager);
+        	
             String publicKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PUBLIC_KEY_FILE_PATH);
             String privateKeyFilePath = PropertiesHolder.getInstance().getProperty(FogbowConstants.PRIVATE_KEY_FILE_PATH);
             ServiceAsymmetricKeysHolder.getInstance().setPublicKeyFilePath(publicKeyFilePath);

--- a/src/main/java/cloud/fogbow/accs/core/datastore/DatabaseManager.java
+++ b/src/main/java/cloud/fogbow/accs/core/datastore/DatabaseManager.java
@@ -4,8 +4,6 @@ import cloud.fogbow.accs.constants.SystemConstants;
 import cloud.fogbow.accs.core.datastore.orderstorage.*;
 import cloud.fogbow.accs.core.datastore.services.RecordService;
 import cloud.fogbow.accs.core.models.AccountingUser;
-import cloud.fogbow.accs.core.datastore.orderstorage.AuditableOrderIdRecorder;
-import cloud.fogbow.accs.core.datastore.orderstorage.AuditableOrderStateChange;
 import cloud.fogbow.accs.core.models.Record;
 import cloud.fogbow.accs.core.models.orders.Order;
 import cloud.fogbow.accs.core.models.orders.OrderState;
@@ -15,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import java.text.ParseException;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 public class DatabaseManager {
@@ -71,13 +70,17 @@ public class DatabaseManager {
     }
 
     public AuditableOrderIdRecorder getIdRecorder() {
-        AuditableOrderIdRecorder idRecorder = auditableOrderIdRecorderRepository.findById(SystemConstants.ID_RECORDER_KEY);
-
-        if (idRecorder == null) {
+        Optional<AuditableOrderIdRecorder> idRecorderOptional = 
+        		auditableOrderIdRecorderRepository.findById(SystemConstants.ID_RECORDER_KEY);
+    	AuditableOrderIdRecorder idRecorder;
+        
+        if (!idRecorderOptional.isPresent()) {
             idRecorder = new AuditableOrderIdRecorder();
             idRecorder.setId(SystemConstants.ID_RECORDER_KEY);
             idRecorder.setCurrentId((0L));
             auditableOrderIdRecorderRepository.save(idRecorder);
+        } else {
+        	idRecorder = idRecorderOptional.get();
         }
 
         return idRecorder;
@@ -88,7 +91,7 @@ public class DatabaseManager {
     }
 
     public Order getOrder(String orderId) {
-        return orderRepository.findById(orderId);
+    	return orderRepository.findById(orderId).orElse(null);
     }
 
     public void saveUser(AccountingUser user) {

--- a/src/main/java/cloud/fogbow/accs/core/datastore/orderstorage/AuditableOrderIdRecorderRepository.java
+++ b/src/main/java/cloud/fogbow/accs/core/datastore/orderstorage/AuditableOrderIdRecorderRepository.java
@@ -1,9 +1,11 @@
 package cloud.fogbow.accs.core.datastore.orderstorage;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuditableOrderIdRecorderRepository extends JpaRepository<AuditableOrderIdRecorder, String> {
 
-    AuditableOrderIdRecorder findById(String id);
+    Optional<AuditableOrderIdRecorder> findById(String id);
 
 }

--- a/src/main/java/cloud/fogbow/accs/core/datastore/orderstorage/OrderRepository.java
+++ b/src/main/java/cloud/fogbow/accs/core/datastore/orderstorage/OrderRepository.java
@@ -1,10 +1,13 @@
 package cloud.fogbow.accs.core.datastore.orderstorage;
 
 import cloud.fogbow.accs.core.models.orders.Order;
+
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, String> {
-    Order findById(String id);
+    Optional<Order> findById(String id);
 }

--- a/src/main/java/cloud/fogbow/accs/core/plugins/AccountingAuthPlugin.java
+++ b/src/main/java/cloud/fogbow/accs/core/plugins/AccountingAuthPlugin.java
@@ -1,6 +1,7 @@
 package cloud.fogbow.accs.core.plugins;
 
 import cloud.fogbow.accs.core.models.AccountingOperation;
+import cloud.fogbow.common.exceptions.ConfigurationErrorException;
 import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
 import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
@@ -10,6 +11,18 @@ public class AccountingAuthPlugin implements AuthorizationPlugin<AccountingOpera
     @Override
     public boolean isAuthorized(SystemUser systemUser, AccountingOperation operation) throws UnauthorizedRequestException {
         return operation.getAllowedUsers().stream()
-            .anyMatch(userName -> userName.equals(systemUser.getName()));
+            .anyMatch(userName -> userName.equals(systemUser.getId()));
     }
+
+	@Override
+	public void setPolicy(String policy) throws ConfigurationErrorException {
+		// Currently there is no implementation 
+		// for this version of AuthorizationPlugin
+	}
+
+	@Override
+	public void updatePolicy(String policy) throws ConfigurationErrorException {
+		// Currently there is no implementation 
+		// for this version of AuthorizationPlugin
+	}
 }

--- a/src/test/java/cloud/fogbow/accs/FogbowAccountingApplicationTests.java
+++ b/src/test/java/cloud/fogbow/accs/FogbowAccountingApplicationTests.java
@@ -4,7 +4,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
+@PowerMockIgnore("jdk.internal.reflect.*")
 @RunWith(PowerMockRunner.class)
 @SpringBootTest
 public class FogbowAccountingApplicationTests {

--- a/src/test/java/cloud/fogbow/accs/core/ApplicationFacadeTest.java
+++ b/src/test/java/cloud/fogbow/accs/core/ApplicationFacadeTest.java
@@ -74,6 +74,7 @@ public class ApplicationFacadeTest extends BaseUnitTests{
     public void testGetUserRecords() throws Exception {
         //setup
         DatabaseManager dbManager = testUtils.mockDbManager();
+        applicationFacade.setDatabaseManager(dbManager);
         Mockito.when(plugin.isAuthorized(Mockito.any(SystemUser.class), Mockito.any(AccountingOperation.class))).thenReturn(true);
         Mockito.when(dbManager.getUserRecords(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
             .thenReturn(getFakeRecordsCollection());
@@ -92,6 +93,7 @@ public class ApplicationFacadeTest extends BaseUnitTests{
     public void testGetSelfRecords() throws FogbowException, ParseException {
         //setup
         DatabaseManager dbManager = testUtils.mockDbManager();
+        applicationFacade.setDatabaseManager(dbManager);
         Mockito.when(plugin.isAuthorized(Mockito.any(SystemUser.class), Mockito.any(AccountingOperation.class))).thenReturn(true);
         Mockito.when(dbManager.getSelfRecords(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any(SystemUser.class)))
                 .thenReturn(getFakeRecordsCollection());

--- a/src/test/java/cloud/fogbow/accs/core/BaseUnitTests.java
+++ b/src/test/java/cloud/fogbow/accs/core/BaseUnitTests.java
@@ -17,7 +17,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @Ignore
 // to avoid classLoader conflict
-@PowerMockIgnore({"javax.management.*"})
+@PowerMockIgnore({"javax.management.*", "jdk.internal.reflect.*"})
 @PrepareForTest({RecordRepository.class, RecordService.class, AuthenticationUtil.class, AccountingPublicKeysHolder.class, DatabaseManager.class})
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(SpringRunner.class)


### PR DESCRIPTION
This PR fixes the component by solving the following issues:
- Repository interfaces did not declare a 'findById' method compatible with the last version of JpaRepository. Fixed by changing the method declaration.
- Conflict between powermock and mockito versions. Fixed by forcing compatible versions in pom.xml.
- DatabaseManager instance used by ApplicationFacade was not initialized correctly. Fixed by adding an Autowired field to Main and setting the created DatabaseManager to the Facade.